### PR TITLE
fixed links to deploy guides on 3.11 with issue 8

### DIFF
--- a/playbooks/coolstore/group_vars/all
+++ b/playbooks/coolstore/group_vars/all
@@ -57,4 +57,4 @@ nexus_max_memory: 2Gi
 
 projects_join_with: "{{ project_cicd }}"
 
-workshopper_content_url_prefix: https://raw.githubusercontent.com/siamaksade/coolstore-demo-guides/openshift-3.11
+workshopper_content_url_prefix: https://raw.githubusercontent.com/siamaksade/coolstore-demo-guides/master

--- a/playbooks/coolstore/msa-cicd-eap-full.yml
+++ b/playbooks/coolstore/msa-cicd-eap-full.yml
@@ -46,7 +46,7 @@
         name: openshift_workshopper
       vars:
         project_name: "{{ project_cicd }}"
-        workshopper_workshop_urls: "{{ workshopper_content_url_prefix }}/demo-cicd-eap-full.yml"
+        workshopper_workshop_urls: "{{ workshopper_content_url_prefix }}/demo-cicd-eap.yml"
         workshopper_env_vars:
           PROJECT_SUFFIX: "{{ project_suffix }}"
           GOGS_URL: http://gogs-{{ project_cicd }}.{{ apps_hostname_suffix }}


### PR DESCRIPTION
This fixes the link and name of the files for guide deployment, specifically for the full msa demo.  There isn't a 3.11 directory so I changed that to master.
https://github.com/siamaksade/openshift-demos-ansible/issues/8
